### PR TITLE
Fuzzer for Redfish Command Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [2.4.1] - 2022-09-08
+- Install Atheris from Google
+- Fuzz the command input using Atheris from Google
+- Fix crash caused by surrogate pair characters
+
 ## [2.4.0] - 2022-08-24
 - Switched to using python requests library for all http operations, urllib has SSL limitations
 - UrlAccess.process_request() does not work with formatted JSON data using json.dumps()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyreadline==2.1
 requests==2.25.0
 urllib3==1.26.5
+atheris==2.0.12

--- a/tests/atheris/fuzzCommandInput.py
+++ b/tests/atheris/fuzzCommandInput.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(os.path.dirname(parent))
+
+import config
+from core.redfishConfig import RedfishConfig
+
+import atheris
+
+with atheris.instrument_imports():
+    from core.redfishCommand import RedfishCommand
+
+def TestOneInput(inputBytes):
+    fdp = atheris.FuzzedDataProvider(inputBytes)
+    # fuzzedData = fdp.ConsumeUnicode(sys.maxsize)
+    fuzzedData = fdp.ConsumeUnicodeNoSurrogates(sys.maxsize)
+
+    redfishConfig = RedfishConfig(config.defaultConfigFile)
+    RedfishCommand.execute(redfishConfig, fuzzedData)
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()

--- a/tests/atheris/fuzzCommandInput.py
+++ b/tests/atheris/fuzzCommandInput.py
@@ -1,3 +1,7 @@
+#
+# Copyright (c) 2022 Seagate Technology LLC and/or its Affiliates, All Rights Reserved
+#
+
 import os
 import sys
 


### PR DESCRIPTION
This pull request contains a fuzzer to fuzz the the Redfish command input using Atheris from Google.

When surrogate pairs are allowed, fix a crash within `core/redfishCommand.py` caused by an uncaught exception.

-----
[View rendered CHANGELOG.md](https://github.com/mjenglish/SystemsRedfishPy/blob/validate_redfish_command_input/CHANGELOG.md)